### PR TITLE
Update Dockerfile.14.8.0-1

### DIFF
--- a/docker/frontend-javascript/Dockerfile.14.8.0-1
+++ b/docker/frontend-javascript/Dockerfile.14.8.0-1
@@ -5,7 +5,7 @@ RUN \
   apt-get install -y build-essential \
                      curl git htop man unzip vim wget libnss3-tools \
                      python python-dev python-pip python-virtualenv \
-                     python3.7 python3-pip python3.7-venv \
+                     python3.7 python3.7-dev python3-pip python3.7-venv \
                      openssh-server \
                      mc git-flow git-extras curl zsh fish jq locales openjdk-8-jre-headless sudo && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
When spinning new container for logger server, an error happens because we do not have the dev package isntalled for python 3.7 (something along the lines of 'Python.h - no such file or directory').

This pull request solves the issue by automatically installing it, so it is there right after building the image.